### PR TITLE
Fix `.sort()` and `.reverse()` when given a single-item map

### DIFF
--- a/src/list/_reverse.sass
+++ b/src/list/_reverse.sass
@@ -7,6 +7,7 @@
 
 @use 'sass:list'
 @use 'sass:math'
+@use 'sass:meta'
 @use '../internal'
 
 
@@ -31,7 +32,10 @@
 	$length: list.length($list)
 
 	@if $length < 2
-		@return $list
+		@if meta.type-of($list) == 'map'
+			@return list.join($list, (), $separator)
+		@else
+			@return $list
 
 	@for $i from 1 through math.floor(math.div($length, 2))
 		$item: list.nth($list, $i)

--- a/src/list/_sort.sass
+++ b/src/list/_sort.sass
@@ -57,6 +57,9 @@
 	@if internal.separator-is-invalid($separator)
 		@error internal.exception-separator('sort')
 
+	@if $separator == 'auto' and meta.type-of($list) == 'map'
+		$separator: 'comma'
+
 	$length: list.length($list)
 
 	@if $center != auto
@@ -72,7 +75,10 @@
 		$center: if($item == null, 0, $item - $item)
 
 	@if $length < 2
-		@return $list
+		@if meta.type-of($list) == 'map'
+			@return list.join($list, (), $separator)
+		@else
+			@return $list
 
 	$middle: math.floor(math.div($length, 2))
 	$left: slice.slice($list, 1, $middle)

--- a/test/list/_reverse.sass
+++ b/test/list/_reverse.sass
@@ -5,6 +5,7 @@
 /// @group tests
 ////
 
+@use 'sass:list'
 @use 'src'
 @use 'true'
 
@@ -29,6 +30,31 @@
 		$assert: src.reverse([1 2 'c' 4 'd'], comma)
 		$expected: ['d', 4, 'c', 2, 1]
 		@include true.assert-equal($assert, $expected)
+
+	@include true.it('Return a list when given a map')
+		$assert: src.reverse((a: 1))
+		$expected: (a 1,)
+		@include true.assert-equal($assert, $expected, '[single value; auto]')
+
+		$assert: src.reverse((a: 1), $separator: comma)
+		$expected: (a 1,)
+		@include true.assert-equal($assert, $expected, '[single value; comma]')
+
+		$assert: src.reverse((a: 1), $separator: space)
+		$expected: list.append((), a 1)
+		@include true.assert-equal($assert, $expected, '[single value; space]')
+
+		$assert: src.reverse((a: 1, b: 2))
+		$expected: (b 2, a 1)
+		@include true.assert-equal($assert, $expected, '[multiple values; auto]')
+
+		$assert: src.reverse((a: 1, b: 2))
+		$expected: (b 2, a 1)
+		@include true.assert-equal($assert, $expected, '[multiple values; comma]')
+
+		$assert: src.reverse((a: 1, b: 2), $separator: space)
+		$expected: (b 2) (a 1)
+		@include true.assert-equal($assert, $expected, '[multiple values; space]')
 
 	@include true.it('Throws when $separator is invalid')
 		$assert: src.reverse(null, null)

--- a/test/list/_sort.sass
+++ b/test/list/_sort.sass
@@ -192,6 +192,31 @@
 		$expected: 'Five', 'Four', 'One', 'Six', 'Three', 'Two'
 		@include true.assert-equal($assert, $expected)
 
+	@include true.it('Return a list when given a map')
+		$assert: src.sort((a: 1))
+		$expected: (a 1,)
+		@include true.assert-equal($assert, $expected, '[single value; auto]')
+
+		$assert: src.sort((a: 1), $separator: comma)
+		$expected: (a 1,)
+		@include true.assert-equal($assert, $expected, '[single value; comma]')
+
+		$assert: src.sort((a: 1), $separator: space)
+		$expected: list.append((), a 1)
+		@include true.assert-equal($assert, $expected, '[single value; space]')
+
+		$assert: src.sort((a: 1, b: 2))
+		$expected: (a 1, b 2)
+		@include true.assert-equal($assert, $expected, '[multiple values; auto]')
+
+		$assert: src.sort((a: 1, b: 2))
+		$expected: (a 1, b 2)
+		@include true.assert-equal($assert, $expected, '[multiple values; comma]')
+
+		$assert: src.sort((a: 1, b: 2), $separator: space)
+		$expected: (a 1) (b 2)
+		@include true.assert-equal($assert, $expected, '[multiple values; space]')
+
 	@include true.it('Throws when $compare is not an function')
 		$assert: src.sort(null, null)
 		$expected: 'ERROR: $compare: `null` is not a function for `sort()`.'


### PR DESCRIPTION
Closes #9 